### PR TITLE
fix: send transactions in topological order

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -159,6 +159,7 @@ export interface PreparedDecodedScript {
 }
 
 export interface PreparedInput {
+  tx_id: string;
   value: number;
   token_data: number;
   script: string;

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -172,7 +172,6 @@ export const BLOCK_BY_HEIGHT: FullBlock = {
         timelock: null
       },
       token: '00',
-      spentBy: null
     }
   ],
   parents: [


### PR DESCRIPTION
Transactions were being sent on the order the algorithm downloaded them (following the parents array)

This was causing an error on the wallet-service because it expects the transactions to come on topological order.