### PR TITLE
fix: get token from decoded data

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -178,7 +178,7 @@ export const prepareTx = (tx: FullTx | FullBlock): PreparedTx => {
         throw new Error('Input is a token but there are no tokens in the tokens list.');
       }
 
-      const { uid } = tx.tokens[wallet.getTokenIndex(input.tokenData) - 1];
+      const { uid } = tx.tokens[wallet.getTokenIndex(input.decoded.tokenData) - 1];
 
       return {
         ...baseInput,
@@ -205,7 +205,7 @@ export const prepareTx = (tx: FullTx | FullBlock): PreparedTx => {
         throw new Error('Output is a token but there are no tokens in the tokens list.');
       }
 
-      const { uid } = tx.tokens[wallet.getTokenIndex(output.tokenData) - 1];
+      const { uid } = tx.tokens[wallet.getTokenIndex(output.decoded.tokenData) - 1];
 
       return {
         ...baseOutput,


### PR DESCRIPTION
Some transactions from the full node are returning invalid token_data on `outputs` and `inputs`, we need to use the data from the `decoded` that seems to be returning the correct information until the fullnode is fixed