### PR TITLE
fix: send height on transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2082,9 +2082,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.171",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.171.tgz",
-      "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==",
+      "version": "4.14.172",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
+      "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==",
       "dev": true
     },
     "@types/node": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "devDependencies": {
     "@size-limit/preset-small-lib": "^4.10.2",
-    "@types/lodash": "^4.14.171",
+    "@types/lodash": "^4.14.172",
     "husky": "^6.0.0",
     "size-limit": "^4.10.2",
     "tsdx": "^0.14.1",

--- a/src/api/lambda.ts
+++ b/src/api/lambda.ts
@@ -54,7 +54,8 @@ export const lambdaCall = (fnName: string, payload: any): Promise<any> => new Pr
 
             resolve(body);
           } catch(e) {
-            logger.error(`Erroed parsing response body: ${data}`);
+            logger.error(`Erroed on lambda call to ${fnName} with payload: ${JSON.stringify(payload)}`);
+            logger.error(e);
 
             return reject(e.message);
           }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -455,6 +455,7 @@ export async function* syncToLatestBlock(): AsyncGenerator<StatusEvent> {
           throw new Error(sendTxResponse.message);
         }
       } catch (e) {
+        logger.error(e);
         yield {
           type: 'transaction_failure',
           success: false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -429,7 +429,6 @@ export async function* syncToLatestBlock(): AsyncGenerator<StatusEvent> {
 
     // Download block transactions
     const txList: Map<string, FullTx> = await recursivelyDownloadTx(block.txId, blockTxs);
-
     const txs: FullTx[] = Array.from(txList.values()).sort((x, y) => x.timestamp - y.timestamp);
 
     // Exclude duplicates:
@@ -446,7 +445,10 @@ export async function* syncToLatestBlock(): AsyncGenerator<StatusEvent> {
 
     txLoop:
       for (const key of Object.keys(uniqueTxs)) {
-      const preparedTx: PreparedTx = prepareTx(uniqueTxs[key]);
+      const preparedTx: PreparedTx = prepareTx({
+        ...uniqueTxs[key],
+        height: block.height, // this tx is confirmed by the current block on the loop, we must send its height
+      });
 
       try {
         const sendTxResponse: ApiResponse = await sendTx(preparedTx);


### PR DESCRIPTION
# Motivation

The sync daemon is currently not sending height on transactions, so they appear on the wallet-service as if they were part of the mempool (height = NULL).

# Acceptance criteria

The daemon should send the transaction object with the height of the block that confirms it on the `height` attribute