### PR TITLE
ci: configure automated deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   push:
-    branches: [dev, master]
+    branches: [dev, master, ci/deploy]
     tags: ['v*.*.*']
 
 env:
@@ -35,6 +35,15 @@ jobs:
           export DOCKER_IMAGE_TAG=${GITHUB_REF#refs/*/}
           make build-and-push-docker
       # TODO Send message to Slack
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@28e8b353eabda5998a2e1203aed33c5999944779
+        env:
+          SLACK_CHANNEL: deploys
+          SLACK_COLOR: ${{ job.status }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_MESSAGE: 'Check if there is a commit here to make sure the deploy worked: https://github.com/HathorNetwork/ops-tools/commits/master'
+          SLACK_TITLE: 'WalletServiceDaemon - Deploying new image :rocket:'
+          SLACK_USERNAME: HathorSlack
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       - name: Clean
         run: |
           rm /home/runner/.docker/config.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,8 @@ jobs:
         if: github.ref == 'refs/heads/dev'
         run: |
           make build-and-push-docker
+
+          echo "environment=dev-testnet" >> $GITHUB_ENV
       - name: Push Testnet Image
         if: github.ref == 'refs/heads/master'
         run: |
@@ -29,21 +31,27 @@ jobs:
           export DOCKER_IMAGE_TAG="master-$commit-$timestamp";
 
           make build-and-push-docker
+
+          echo "environment=testnet" >> $GITHUB_ENV
       - name: Push Mainnet Image
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           export DOCKER_IMAGE_TAG=${GITHUB_REF#refs/*/}
           make build-and-push-docker
+
+          echo "environment=mainnet" >> $GITHUB_ENV
       # TODO Send message to Slack
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@28e8b353eabda5998a2e1203aed33c5999944779
         env:
           SLACK_CHANNEL: deploys
           SLACK_COLOR: ${{ job.status }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_MESSAGE: 'Check if there is a commit here to make sure the deploy worked: https://github.com/HathorNetwork/ops-tools/commits/master'
-          SLACK_TITLE: 'WalletServiceDaemon - Deploying new image :rocket:'
+          SLACK_MESSAGE: 'Make sure the image is correctly deployed by checking if a new commit by fluxcdbot was made: https://github.com/HathorNetwork/ops-tools/commits/master'
+          SLACK_TITLE: 'WalletServiceDaemon - new ${{ env.environment }} Docker image pushed :rocket:'
           SLACK_USERNAME: HathorSlack
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_FOOTER: ''
+          MSG_MINIMAL: actions url
       - name: Clean
         run: |
           rm /home/runner/.docker/config.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: deploy
+
+on:
+  push:
+    branches: [dev, master]
+    tags: ['v*.*.*']
+
+env:
+  AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: 'eu-central-1'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Push Dev Image
+        if: github.ref == 'refs/heads/dev'
+        run: |
+          make build-and-push-docker
+      - name: Push Testnet Image
+        if: github.ref == 'refs/heads/master'
+        run: |
+          commit=`git rev-parse HEAD`;
+          timestamp=`date +%s`;
+          export DOCKER_IMAGE_TAG="master-$commit-$timestamp";
+
+          make build-and-push-docker
+      - name: Push Mainnet Image
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          export DOCKER_IMAGE_TAG=${GITHUB_REF#refs/*/}
+          make build-and-push-docker
+      # TODO Send message to Slack
+      - name: Clean
+        run: |
+          rm /home/runner/.docker/config.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,14 +40,13 @@ jobs:
           make build-and-push-docker
 
           echo "deployed_environment=mainnet" >> $GITHUB_ENV
-      # TODO Send message to Slack
       - name: Slack Notification
         if: env.deployed_environment
         uses: rtCamp/action-slack-notify@28e8b353eabda5998a2e1203aed33c5999944779
         env:
           SLACK_CHANNEL: deploys
           SLACK_COLOR: ${{ job.status }} # or a specific color like 'good' or '#ff00ff'
-          SLACK_MESSAGE: 'Make sure the image is correctly deployed by checking if a new commit by fluxcdbot was made: https://github.com/HathorNetwork/ops-tools/commits/master'
+          SLACK_MESSAGE: 'Make sure the image is correctly deployed by checking if a new commit by fluxcdbot was made in: https://github.com/HathorNetwork/ops-tools/commits/master'
           SLACK_TITLE: 'WalletServiceDaemon - new ${{ env.deployed_environment }} Docker image pushed :rocket:'
           SLACK_USERNAME: HathorSlack
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           make build-and-push-docker
 
-          echo "environment=dev-testnet" >> $GITHUB_ENV
+          echo "deployed_environment=dev-testnet" >> $GITHUB_ENV
       - name: Push Testnet Image
         if: github.ref == 'refs/heads/master'
         run: |
@@ -32,22 +32,23 @@ jobs:
 
           make build-and-push-docker
 
-          echo "environment=testnet" >> $GITHUB_ENV
+          echo "deployed_environment=testnet" >> $GITHUB_ENV
       - name: Push Mainnet Image
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           export DOCKER_IMAGE_TAG=${GITHUB_REF#refs/*/}
           make build-and-push-docker
 
-          echo "environment=mainnet" >> $GITHUB_ENV
+          echo "deployed_environment=mainnet" >> $GITHUB_ENV
       # TODO Send message to Slack
       - name: Slack Notification
+        if: env.deployed_environment
         uses: rtCamp/action-slack-notify@28e8b353eabda5998a2e1203aed33c5999944779
         env:
           SLACK_CHANNEL: deploys
           SLACK_COLOR: ${{ job.status }} # or a specific color like 'good' or '#ff00ff'
           SLACK_MESSAGE: 'Make sure the image is correctly deployed by checking if a new commit by fluxcdbot was made: https://github.com/HathorNetwork/ops-tools/commits/master'
-          SLACK_TITLE: 'WalletServiceDaemon - new ${{ env.environment }} Docker image pushed :rocket:'
+          SLACK_TITLE: 'WalletServiceDaemon - new ${{ env.deployed_environment }} Docker image pushed :rocket:'
           SLACK_USERNAME: HathorSlack
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_FOOTER: ''

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Install deps and build (with cache)
-        uses: bahmutov/npm-install@v1
+        uses: bahmutov/npm-install@c67aaab58a864ea2873950cde9c1c9379f9f711a
 
       - name: Lint
         run: yarn lint


### PR DESCRIPTION
### Acceptance Criteria
- We should build and push a Docker image to our registry, when commits/tags are created.
- We should tag the images according to the branch/tag:
    - `dev` branch: `dev-$commit-$timestamp` pattern
    - `master` branch: `master-$commit-$timestamp` pattern
    - git tags: the tag is also used as the Docker tag.
- We should send a message to Slack when new images are pushed

### Additional Notes
The failing tests are caused by an old CI pipeline that we had in this repo, not by the one created in this PR. It didn't fail before because Github Actions was disabled in this repo.