### PR TITLE
fix: validating decoded data before trying to get the token data

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,7 +36,7 @@ import dotenv from 'dotenv';
 // @ts-ignore
 import { wallet } from '@hathor/wallet-lib';
 import logger from './logger';
-import { isNumber } from 'lodash';
+import { isNumber, isEmpty } from 'lodash';
 
 dotenv.config();
 
@@ -222,6 +222,12 @@ export const prepareTx = (tx: FullTx | FullBlock): PreparedTx => {
         throw new Error(
           'Output is a token but there are no tokens in the tokens list.'
         );
+      }
+
+      if (!output.decoded
+          || isEmpty(output.decoded)
+          || !output.decoded.type) {
+        return baseOutput;
       }
 
       const { uid } = tx.tokens[

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -224,9 +224,7 @@ export const prepareTx = (tx: FullTx | FullBlock): PreparedTx => {
         );
       }
 
-      if (!output.decoded
-          || isEmpty(output.decoded)
-          || !output.decoded.type) {
+      if (!output.decoded || isEmpty(output.decoded) || !output.decoded.type) {
         return baseOutput;
       }
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -14,6 +14,7 @@ import {
   BLOCK_BY_HEIGHT,
   MOCK_TXS,
   MOCK_FULL_TXS,
+  MOCK_NFT_TX,
   MOCK_CREATE_TOKEN_TX,
   generateBlock,
 } from './utils';
@@ -390,4 +391,16 @@ test('prepareTx on a CREATE_TOKEN tx should have token_name and token_symbol', a
 
   expect(preparedTx.token_name).toStrictEqual('XCoin');
   expect(preparedTx.token_symbol).toStrictEqual('XCN');
+}, 500);
+
+test('prepareTx on a NFT transaction should not throw', async () => {
+  expect.hasAssertions();
+
+  const { tx } = MOCK_NFT_TX;
+  const parsedTx = parseTx(tx);
+  const preparedTx = prepareTx(parsedTx);
+
+  expect(preparedTx.outputs[0].decoded.type).toStrictEqual(undefined);
+  expect(preparedTx.outputs[0].value).toStrictEqual(1);
+  expect(preparedTx.outputs[0].token_data).toStrictEqual(0);
 }, 500);


### PR DESCRIPTION
# Acceptance criteria

The daemon should send NFT transactions properly to the wallet-service
