### PR TITLE
feat: alert string on critical failure

### DIFF
--- a/src/machine.ts
+++ b/src/machine.ts
@@ -228,6 +228,7 @@ export const SyncMachine = Machine<SyncContext, SyncSchema>(
       },
       failure: {
         type: 'final',
+        entry: ['logFailure'],
       },
     },
   },
@@ -237,6 +238,10 @@ export const SyncMachine = Machine<SyncContext, SyncSchema>(
       hasMempoolUpdate: ctx => ctx.hasMempoolUpdate,
     },
     actions: {
+      // @ts-ignore
+      logFailure: () => {
+        logger.error('[ALERT] Machine transitioned to failure state.');
+      },
       // @ts-ignore
       resetMoreBlocks: assign({
         hasMoreBlocks: () => false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -344,7 +344,7 @@ export async function* syncLatestMempool(): AsyncGenerator<MempoolEvent> {
       yield {
         type: 'error',
         success: false,
-        message: `Failure on transaction ${mempoolResp.transactions[i]} in mempool`,
+        message: `[ALERT] Failure on transaction ${mempoolResp.transactions[i]} in mempool`,
       };
       return;
     }
@@ -361,7 +361,7 @@ export async function* syncLatestMempool(): AsyncGenerator<MempoolEvent> {
       yield {
         type: 'error',
         success: false,
-        message: `Failure on transaction ${preparedTx.tx_id} in mempool`,
+        message: `[ALERT] Failure on transaction ${preparedTx.tx_id} in mempool`,
       };
       return;
     }


### PR DESCRIPTION
# Acceptance criteria

The daemon should log a string with "[ALERT]" so it will generate an alarm on slack when it transitions on the failure state and on important failures