### PR TITLE
chore: alert on fullnode connection error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ conn.on('state', state =>
 );
 // @ts-ignore
 conn.websocket.on('connection_error', evt => {
-  logger.error(`Websocket connection error: ${evt.message}`);
+  logger.error(`[ALERT] Websocket connection error: ${evt.message}`);
 });
 
 machine.start();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -361,7 +361,7 @@ export async function* syncLatestMempool(): AsyncGenerator<MempoolEvent> {
       yield {
         type: 'error',
         success: false,
-        message: `[ALERT] Failure on transaction ${preparedTx.tx_id} in mempool`,
+        message: `[ALERT] Failure on transaction ${preparedTx.tx_id} in mempool: ${e.message}`,
       };
       return;
     }


### PR DESCRIPTION
# Acceptance criteria

Errors on the connection with the fullnode should have an "ALERT" string so it will be logged to Slack critical alerts channel

Also, failures on mempool sync should log the error message