### PR TITLE
refactor: including voided transactions on recursivelyDownloadTx and …

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export interface FullTx {
   timestamp: number;
   version: number;
   weight: number;
+  voided?: boolean;
   parents: string[];
   tokenName?: string | null;
   tokenSymbol?: string | null;


### PR DESCRIPTION
## Motivation

Currently, we recursively download all transactions from a block by going through the DAG of transactions using the parent array

Before this PR we were ignoring voided transactions, so if the block had only voided transactions as parents, we would not go further in the transaction DAG

### Acceptance Criteria
- We should download the full DAG of transactions, even if both parents of a block are voided
- We should filter the voided transactions before sending them to the wallet-service


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
