### PR TITLE
refactor: recursivelyDownloadTx now downloads the input tree as well

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -132,8 +132,8 @@ export const recursivelyDownloadTx = async (
     return recursivelyDownloadTx(blockId, blockHeight, txIds, data);
   }
 
-  // Transaction is already confirmed
-  if (meta.first_block) {
+  // Transaction was already confirmed by a different block in the past
+  if (meta.first_block && meta.first_block !== blockId) {
     const firstBlockResponse = await downloadTx(meta.first_block);
 
     // If the transaction was confirmed by an older block, ignore it as it was

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,6 +96,8 @@ export const downloadTxFromId = async (
  * This method will go through the parent tree and the inputs tree downloading all transactions,
  * while ignoring transactions confirmed by blocks with height < blockHeight
  *
+ * NOTE: This operation will get slower and slower as the BFS dives into the funds and the confirmation DAGs 
+ *
  * @param blockId - The blockId to download the transactions
  * @param blockHeight - The block height from the block we are downloading transactions from
  * @param txIds - List of transactions to download
@@ -132,7 +134,7 @@ export const recursivelyDownloadTx = async (
     return recursivelyDownloadTx(blockId, blockHeight, txIds, data);
   }
 
-  // Transaction was already confirmed by a different block in the past
+  // Transaction was already confirmed by a different block
   if (meta.first_block && meta.first_block !== blockId) {
     const firstBlockResponse = await downloadTx(meta.first_block);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -91,9 +91,13 @@ export const downloadTxFromId = async (
 };
 
 /**
- * Recursively downloads all transactions that were confirmed by a given block
+ * Recursively downloads all transactions confirmed directly or indirectly by a block
+ *
+ * This method will go through the parent tree and the inputs tree downloading all transactions,
+ * while ignoring transactions confirmed by the passed block
  *
  * @param blockId - The blockId to download the transactions
+ * @param blockHeight - The block height from the block we are downloading transactions from
  * @param txIds - List of transactions to download
  * @param data - Downloaded transactions, used while being called recursively
  */
@@ -139,22 +143,18 @@ export const recursivelyDownloadTx = async (
     }
   }
 
-  /* if (meta.first_block !== blockId) {
-    return recursivelyDownloadTx(blockId, blockHeight, txIds, data);
-  } */
-
- const txList = [...parsedTx.parents, ...parsedTx.inputs.map((input) => input.txId)];
+  const inputList = parsedTx.inputs.map((input) => input.txId);
+  const txList = [...parsedTx.parents, ...inputList];
 
   // check if we have already downloaded the parents
-  const newTxIds = txList.filter(parent => {
+  const newTxIds = txList.filter(transaction => {
     return (
-      txIds.indexOf(parent) < 0 &&
+      txIds.indexOf(transaction) < 0 &&
       /* Removing the current tx from the list of transactions to download: */
-      parent !== txId &&
+      transaction !== txId &&
       /* Data works as our return list on the recursion and also as a "seen" list on the BFS.
-       * We don't want to download a transaction that is already on our seen list.
-       */
-      !data.has(parent)
+       * We don't want to download a transaction that is already on our seen list. */
+      !data.has(transaction)
     );
   });
 


### PR DESCRIPTION
Fixes https://github.com/HathorNetwork/hathor-wallet-service/issues/227


### Acceptance Criteria
- We should get not only the transactions that have the block we are downloading as first_block but also the input tree for that transaction, ignoring transactions that were confirmed by previous blocks


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
