### PR TITLE
refactor: using a Set to reduce time complexity on recursivelyDownloadTx

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -147,11 +147,12 @@ export const recursivelyDownloadTx = async (
 
   const inputList = parsedTx.inputs.map((input) => input.txId);
   const txList = [...parsedTx.parents, ...inputList];
+  const txIdsSet = new Set(txIds);
 
   // check if we have already downloaded any of the transactions of the new list
   const newTxIds = txList.filter(transaction => {
     return (
-      txIds.indexOf(transaction) < 0 &&
+      !txIdsSet.has(transaction) &&
       /* Removing the current tx from the list of transactions to download: */
       transaction !== txId &&
       /* Data works as our return list on the recursion and also as a "seen" list on the BFS.


### PR DESCRIPTION
This PR fixes https://github.com/HathorNetwork/hathor-wallet-service-sync_daemon/issues/48

### Acceptance Criteria
- Our `txList` filter algorithm at the end of the `recursivelyDownloadTx` method should run in `O(n + m)` instead of `O(n * m)` where `n` is `txIds.length` and `m` is `txList.length`


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
