### PR TITLE
feat: send network name to alert-manager

### DIFF
--- a/src/api/lambda.ts
+++ b/src/api/lambda.ts
@@ -80,6 +80,7 @@ export const addAlert = async (title: string, message: string, severity: Severit
     message,
     severity,
     metadata,
+    environment: process.env.NETWORK,
     application: process.env.APPLICATION_NAME,
   };
 


### PR DESCRIPTION
depends on: https://github.com/HathorNetwork/alert-manager/pull/15

### Acceptance Criteria
- We should send the Network name to alert-manager. It will use it for the deduplication mechanism (otherwise the same alert happening in the Mainnet and Testnet could be deduplicated wrongly)


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
