### PR TITLE
fix: handling throwing lambda call

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -588,13 +588,18 @@ export async function* syncToLatestBlock(): AsyncGenerator<StatusEvent> {
       }
     }
 
-    // We will send the block only after all transactions were sent
-    // to be sure that all downloads were succesfull since there is no
-    // ROLLBACK yet on the wallet-service.
-    const sendBlockResponse: ApiResponse = await sendTx(preparedBlock);
+    try {
+      // We will send the block only after all transactions were sent
+      // to be sure that all downloads were succesfull since there is no
+      // ROLLBACK yet on the wallet-service.
+      const sendBlockResponse: ApiResponse = await sendTx(preparedBlock);
 
-    if (!sendBlockResponse.success) {
-      logger.debug(sendBlockResponse);
+      if (!sendBlockResponse.success) {
+        logger.debug(sendBlockResponse);
+        throw new Error('Erroed sending block to the wallet-service.');
+      }
+    } catch(e) {
+      logger.error(e);
       addAlert(
         'Failed to send block transaction',
         `Failure on block ${preparedBlock.tx_id}`,


### PR DESCRIPTION
This is related to the error described in https://github.com/HathorNetwork/on-call-incidents/issues/87

### Acceptance Criteria
- If the lambda call throws instead of gracefully returning an error, we should catch it and handle it properly by sending the alert to alert-manager and transitioning to the `failure` state.


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
